### PR TITLE
[install] install python3-matplotlib

### DIFF
--- a/20-install
+++ b/20-install
@@ -54,6 +54,7 @@ python3
 python3-click
 python3-dev
 python3-libtmux
+python3-matplotlib
 python3-numpy
 python3-pexpect
 python3-pip


### PR DESCRIPTION
Matplotlib is needed in the CI of emper-io-eval to check the python code.

Needs a new release after this.